### PR TITLE
Support randomized XVM hash tables

### DIFF
--- a/xvm/Makefile
+++ b/xvm/Makefile
@@ -5,7 +5,7 @@
 # Available for Windows, macOS, and Linux
 # ═══════════════════════════════════════════════════════════════════════════
 
-.PHONY: all build xenlybyc xenlyrun clean test fmt vet help
+.PHONY: all build xenlybyc xenlyrun xenlyimg clean test fmt vet help
 
 GOCMD   = go
 GOBUILD = $(GOCMD) build
@@ -17,12 +17,14 @@ GOVET   = $(GOCMD) vet
 BINDIR    = bin
 XENLYBYC  = $(BINDIR)/xenlybyc
 XENLYRUN  = $(BINDIR)/xenlyrun
+XENLYIMG  = $(BINDIR)/xenlyimg
 
 # Windows suffix
 ifeq ($(OS),Windows_NT)
     EXE = .exe
     XENLYBYC := $(XENLYBYC).exe
     XENLYRUN := $(XENLYRUN).exe
+    XENLYIMG := $(XENLYIMG).exe
 endif
 
 # Build flags
@@ -31,11 +33,12 @@ BUILD_FLAGS =
 
 all: build
 
-build: xenlybyc xenlyrun
+build: xenlybyc xenlyrun xenlyimg
 	@echo ""
 	@echo "✓  XVM build complete"
 	@echo "   Bytecode compiler : $(XENLYBYC)"
 	@echo "   VM launcher       : $(XENLYRUN)"
+	@echo "   Native image AOT  : $(XENLYIMG)"
 	@echo ""
 
 xenlybyc:
@@ -50,32 +53,43 @@ xenlyrun:
 	$(GOBUILD) $(BUILD_FLAGS) $(LDFLAGS) -o $(XENLYRUN) ./xenlyrun/
 	@echo "  ✓  $(XENLYRUN)"
 
+xenlyimg:
+	@mkdir -p $(BINDIR)
+	@echo "Building xenlyimg..."
+	$(GOBUILD) $(BUILD_FLAGS) $(LDFLAGS) -o $(XENLYIMG) ./xenlyimg/
+	@echo "  ✓  $(XENLYIMG)"
+
 # ── Cross compilation ────────────────────────────────────────────────────────
 
 cross-linux-amd64:
 	@mkdir -p $(BINDIR)
 	GOOS=linux   GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlybyc-linux-amd64   ./xenlybyc/
 	GOOS=linux   GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyrun-linux-amd64   ./xenlyrun/
+	GOOS=linux   GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyimg-linux-amd64   ./xenlyimg/
 
 cross-linux-arm64:
 	@mkdir -p $(BINDIR)
 	GOOS=linux   GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlybyc-linux-arm64   ./xenlybyc/
 	GOOS=linux   GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyrun-linux-arm64   ./xenlyrun/
+	GOOS=linux   GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyimg-linux-arm64   ./xenlyimg/
 
 cross-darwin-amd64:
 	@mkdir -p $(BINDIR)
 	GOOS=darwin  GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlybyc-darwin-amd64  ./xenlybyc/
 	GOOS=darwin  GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyrun-darwin-amd64  ./xenlyrun/
+	GOOS=darwin  GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyimg-darwin-amd64  ./xenlyimg/
 
 cross-darwin-arm64:
 	@mkdir -p $(BINDIR)
 	GOOS=darwin  GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlybyc-darwin-arm64  ./xenlybyc/
 	GOOS=darwin  GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyrun-darwin-arm64  ./xenlyrun/
+	GOOS=darwin  GOARCH=arm64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyimg-darwin-arm64  ./xenlyimg/
 
 cross-windows-amd64:
 	@mkdir -p $(BINDIR)
 	GOOS=windows GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlybyc-windows-amd64.exe ./xenlybyc/
 	GOOS=windows GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyrun-windows-amd64.exe ./xenlyrun/
+	GOOS=windows GOARCH=amd64   $(GOBUILD) $(LDFLAGS) -o $(BINDIR)/xenlyimg-windows-amd64.exe ./xenlyimg/
 
 cross-all: cross-linux-amd64 cross-linux-arm64 cross-darwin-amd64 cross-darwin-arm64 cross-windows-amd64
 	@echo "✓  All cross-compile targets built"
@@ -91,7 +105,10 @@ test: build
 	@echo "  ✓  xenlybyc compiled hello"
 	$(XENLYRUN) /tmp/xvm_test.xebc
 	@echo "  ✓  xenlyrun executed hello"
-	@rm -f /tmp/xvm_test.xe /tmp/xvm_test.xebc
+	$(XENLYIMG) /tmp/xvm_test.xebc -o /tmp/xvm_test_native
+	/tmp/xvm_test_native
+	@echo "  ✓  xenlyimg built and executed native hello"
+	@rm -f /tmp/xvm_test.xe /tmp/xvm_test.xebc /tmp/xvm_test_native
 	$(GOTEST) ./...
 	@echo "✓  All tests passed"
 
@@ -120,11 +137,13 @@ install: build
 	install -d $(BININSTDIR)
 	install -m 755 $(XENLYBYC) $(BININSTDIR)/xenlybyc$(EXE)
 	install -m 755 $(XENLYRUN)  $(BININSTDIR)/xenlyrun$(EXE)
+	install -m 755 $(XENLYIMG)  $(BININSTDIR)/xenlyimg$(EXE)
 	@echo "✓  Installed to $(BININSTDIR)"
 
 uninstall:
 	rm -f $(BININSTDIR)/xenlybyc$(EXE)
 	rm -f $(BININSTDIR)/xenlyrun$(EXE)
+	rm -f $(BININSTDIR)/xenlyimg$(EXE)
 	@echo "✓  Uninstalled"
 
 # ── Help ──────────────────────────────────────────────────────────────────────
@@ -138,6 +157,7 @@ help:
 	@echo "    all              Build xenlybyc + xenlyrun (default)"
 	@echo "    xenlybyc         Build the bytecode compiler only"
 	@echo "    xenlyrun         Build the VM launcher only"
+	@echo "    xenlyimg         Build the native image builder only"
 	@echo "    test             Build and run test suite"
 	@echo "    fmt              Auto-format all Go source"
 	@echo "    vet              Run go vet on all packages"
@@ -160,6 +180,7 @@ help:
 	@echo "    make test                    # build + smoke test"
 	@echo "    ./bin/xenlybyc hello.xe      # compile hello.xe → hello.xebc"
 	@echo "    ./bin/xenlyrun  hello.xebc    # run compiled bytecode"
+	@echo "    ./bin/xenlyimg  hello.xebc -o hello  # build native executable"
 	@echo "    ./bin/xenlyrun --run hello.xe  # compile + run in one step"
 	@echo "    make cross-all               # build for all platforms"
 	@echo ""

--- a/xvm/README.md
+++ b/xvm/README.md
@@ -4,7 +4,7 @@
 
 It is written in **Go** programming language.
 
-| Operating systems               | `XVM` was working (`xenlybyc` and `xenlyrun`) |
+| Operating systems               | `XVM` was working (`xenlybyc`, `xenlyrun`, and `xenlyimg`) |
 |:-------------------------------:|:----------------------------------------:|
 | **Windows**                     | Yes ✔️                                   |
 | **Windows Subsystem for Linux** | Yes ✔️                                   |
@@ -15,6 +15,7 @@ It is written in **Go** programming language.
 
 * `.xe` and `.xenly` (**Xenly source file**) — It is the source file for the Xenly programming language.
 * `.xebc` (**Xenly bytecode** or **Xenly byteclass**) - a file containing Xenly bytecode that can be executed on the XVM.
+* Native executable (`.exe` on Windows, no fixed suffix on macOS/Linux) - a standalone, platform-specific image produced by `xenlyimg`.
 
 ## Getting started
 1. Install Go 1.21+ from [go.dev/dl](https://go.dev/dl) if you don't have it:
@@ -46,6 +47,24 @@ It is written in **Go** programming language.
 4. **`xenlyrun`** (Xenly bytecode interpreter) can be executed:
    ```bash
    $ ./bin/xenlyrun hello.xebc
+   ```
+
+5. **`xenlyimg`** (XVM native image builder) can ahead-of-time compile XVM bytecode into a standalone native executable for Windows, macOS, or Linux:
+   ```bash
+   $ ./bin/xenlyimg hello.xebc -o hello
+   $ ./hello
+   ```
+
+   Cross-build a native image for another supported target with `--target`:
+   ```bash
+   $ ./bin/xenlyimg hello.xebc --target linux/amd64 -o hello-linux-amd64
+   $ ./bin/xenlyimg hello.xebc --target windows/amd64 -o hello.exe
+   ```
+
+   The complete native-image pipeline is:
+   ```bash
+   $ ./bin/xenlybyc hello.xe -o hello.xebc
+   $ ./bin/xenlyimg hello.xebc -o hello
    ```
 
 ## Copyright

--- a/xvm/install-go.py
+++ b/xvm/install-go.py
@@ -24,9 +24,9 @@ if os.name == "nt":
 
 LDFLAGS = ["-ldflags", "-s -w"]
 
-def run(cmd):
+def run(cmd, env=None):
     print(" ".join(cmd))
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, env=env)
 
 def ensure_bindir():
     os.makedirs(BINDIR, exist_ok=True)
@@ -72,9 +72,9 @@ def cross_compile(goos, goarch):
     env["GOOS"] = goos
     env["GOARCH"] = goarch
 
-    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlybyc-{suffix}{exe}", "./xenlybyc/"])
-    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyrun-{suffix}{exe}", "./xenlyrun/"])
-    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyimg-{suffix}{exe}", "./xenlyimg/"])
+    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlybyc-{suffix}{exe}", "./xenlybyc/"], env=env)
+    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyrun-{suffix}{exe}", "./xenlyrun/"], env=env)
+    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyimg-{suffix}{exe}", "./xenlyimg/"], env=env)
 
 def cross_all():
     targets = [

--- a/xvm/install-go.py
+++ b/xvm/install-go.py
@@ -15,10 +15,12 @@ import shutil
 BINDIR = "bin"
 XENLYBYC = os.path.join(BINDIR, "xenlybyc")
 XENLYRUN = os.path.join(BINDIR, "xenlyrun")
+XENLYIMG = os.path.join(BINDIR, "xenlyimg")
 
 if os.name == "nt":
     XENLYBYC += ".exe"
     XENLYRUN += ".exe"
+    XENLYIMG += ".exe"
 
 LDFLAGS = ["-ldflags", "-s -w"]
 
@@ -43,12 +45,20 @@ def build_xenlyrun():
     run(["go", "build", *LDFLAGS, "-o", XENLYRUN, "./xenlyrun/"])
     print("✓", XENLYRUN)
 
+def build_xenlyimg():
+    ensure_bindir()
+    print("Building xenlyimg...")
+    run(["go", "build", *LDFLAGS, "-o", XENLYIMG, "./xenlyimg/"])
+    print("✓", XENLYIMG)
+
 def build():
     build_xenlybyc()
     build_xenlyrun()
+    build_xenlyimg()
     print("\n✓ XVM build complete")
     print("Bytecode compiler :", XENLYBYC)
     print("VM launcher       :", XENLYRUN)
+    print("Native image AOT  :", XENLYIMG)
 
 # ── Cross Compile ─────────────────────────────────────
 
@@ -64,6 +74,7 @@ def cross_compile(goos, goarch):
 
     run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlybyc-{suffix}{exe}", "./xenlybyc/"])
     run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyrun-{suffix}{exe}", "./xenlyrun/"])
+    run(["go", "build", *LDFLAGS, "-o", f"{BINDIR}/xenlyimg-{suffix}{exe}", "./xenlyimg/"])
 
 def cross_all():
     targets = [
@@ -98,8 +109,15 @@ def test():
     run([XENLYRUN, bytecode])
     print("✓ xenlyrun executed hello")
 
+    native = "/tmp/xvm_test_native" + (".exe" if os.name == "nt" else "")
+    run([XENLYIMG, bytecode, "-o", native])
+    run([native])
+    print("✓ xenlyimg built and executed native hello")
+
     os.remove(testfile)
     os.remove(bytecode)
+    if os.path.exists(native):
+        os.remove(native)
 
     run(["go","test","./..."])
     print("✓ All tests passed")
@@ -135,6 +153,7 @@ Commands:
   build        Build xenlybyc + xenlyrun
   xenlybyc     Build bytecode compiler only
   xenlyrun     Build VM launcher only
+  xenlyimg     Build native image builder only
   test         Build and run test suite
   fmt          Format Go source
   vet          Run go vet
@@ -155,6 +174,7 @@ commands = {
     "build": build,
     "xenlybyc": build_xenlybyc,
     "xenlyrun": build_xenlyrun,
+    "xenlyimg": build_xenlyimg,
     "cross-all": cross_all,
     "test": test,
     "fmt": fmt,

--- a/xvm/main.bat
+++ b/xvm/main.bat
@@ -12,6 +12,7 @@ REM Configuration
 set BINDIR=bin
 set XENLYBYC=%BINDIR%\xenlybyc.exe
 set XENLYRUN=%BINDIR%\xenlyrun.exe
+set XENLYIMG=%BINDIR%\xenlyimg.exe
 set LDFLAGS=-ldflags="-s -w"
 
 if "%1"=="" goto build
@@ -19,6 +20,7 @@ if "%1"=="all" goto build
 if "%1"=="build" goto build
 if "%1"=="xenlybyc" goto xenlybyc
 if "%1"=="xenlyrun" goto xenlyrun
+if "%1"=="xenlyimg" goto xenlyimg
 if "%1"=="clean" goto clean
 if "%1"=="test" goto test
 if "%1"=="fmt" goto fmt
@@ -39,10 +41,12 @@ goto help
 :build
 call :xenlybyc
 call :xenlyrun
+call :xenlyimg
 echo.
 echo ✓  XVM build complete
 echo    Bytecode compiler : %XENLYBYC%
 echo    VM launcher       : %XENLYRUN%
+echo    Native image AOT  : %XENLYIMG%
 echo.
 goto end
 
@@ -60,12 +64,20 @@ go build %LDFLAGS% -o %XENLYRUN% .\xenlyrun\
 echo   ✓  %XENLYRUN%
 goto end
 
+:xenlyimg
+if not exist %BINDIR% mkdir %BINDIR%
+echo Building xenlyimg...
+go build %LDFLAGS% -o %XENLYIMG% .\xenlyimg\
+echo   ✓  %XENLYIMG%
+goto end
+
 :cross-linux-amd64
 if not exist %BINDIR% mkdir %BINDIR%
 set GOOS=linux
 set GOARCH=amd64
 go build %LDFLAGS% -o %BINDIR%\xenlybyc-linux-amd64 .\xenlybyc\
 go build %LDFLAGS% -o %BINDIR%\xenlyrun-linux-amd64 .\xenlyrun\
+go build %LDFLAGS% -o %BINDIR%\xenlyimg-linux-amd64 .\xenlyimg\
 goto end
 
 :cross-linux-arm64
@@ -74,6 +86,7 @@ set GOOS=linux
 set GOARCH=arm64
 go build %LDFLAGS% -o %BINDIR%\xenlybyc-linux-arm64 .\xenlybyc\
 go build %LDFLAGS% -o %BINDIR%\xenlyrun-linux-arm64 .\xenlyrun\
+go build %LDFLAGS% -o %BINDIR%\xenlyimg-linux-arm64 .\xenlyimg\
 goto end
 
 :cross-darwin-amd64
@@ -82,6 +95,7 @@ set GOOS=darwin
 set GOARCH=amd64
 go build %LDFLAGS% -o %BINDIR%\xenlybyc-darwin-amd64 .\xenlybyc\
 go build %LDFLAGS% -o %BINDIR%\xenlyrun-darwin-amd64 .\xenlyrun\
+go build %LDFLAGS% -o %BINDIR%\xenlyimg-darwin-amd64 .\xenlyimg\
 goto end
 
 :cross-darwin-arm64
@@ -90,6 +104,7 @@ set GOOS=darwin
 set GOARCH=arm64
 go build %LDFLAGS% -o %BINDIR%\xenlybyc-darwin-arm64 .\xenlybyc\
 go build %LDFLAGS% -o %BINDIR%\xenlyrun-darwin-arm64 .\xenlyrun\
+go build %LDFLAGS% -o %BINDIR%\xenlyimg-darwin-arm64 .\xenlyimg\
 goto end
 
 :cross-windows-amd64
@@ -98,6 +113,7 @@ set GOOS=windows
 set GOARCH=amd64
 go build %LDFLAGS% -o %BINDIR%\xenlybyc-windows-amd64.exe .\xenlybyc\
 go build %LDFLAGS% -o %BINDIR%\xenlyrun-windows-amd64.exe .\xenlyrun\
+go build %LDFLAGS% -o %BINDIR%\xenlyimg-windows-amd64.exe .\xenlyimg\
 goto end
 
 :cross-all
@@ -119,7 +135,10 @@ echo print("Hello, World!")> %TEMP%\xvm_test.xe
 echo   ✓  xenlybyc compiled hello
 %XENLYRUN% %TEMP%\xvm_test.xyc
 echo   ✓  xenlyrun executed hello
-del /f /q %TEMP%\xvm_test.xe %TEMP%\xvm_test.xyc 2>nul
+%XENLYIMG% %TEMP%\xvm_test.xyc -o %TEMP%\xvm_test_native.exe
+%TEMP%\xvm_test_native.exe
+echo   ✓  xenlyimg built and executed native hello
+del /f /q %TEMP%\xvm_test.xe %TEMP%\xvm_test.xyc %TEMP%\xvm_test_native.exe 2>nul
 go test ./...
 echo ✓  All tests passed
 goto end
@@ -147,6 +166,7 @@ set BININSTDIR=%PREFIX%\bin
 if not exist %BININSTDIR% mkdir %BININSTDIR%
 copy /y %XENLYBYC% %BININSTDIR%\xenlybyc.exe >nul
 copy /y %XENLYRUN% %BININSTDIR%\xenlyrun.exe >nul
+copy /y %XENLYIMG% %BININSTDIR%\xenlyimg.exe >nul
 echo ✓  Installed to %BININSTDIR%
 goto end
 
@@ -156,6 +176,7 @@ if "%PREFIX%"=="" set PREFIX=C:\Program Files\Xenly
 set BININSTDIR=%PREFIX%\bin
 del /f /q %BININSTDIR%\xenlybyc.exe 2>nul
 del /f /q %BININSTDIR%\xenlyrun.exe 2>nul
+del /f /q %BININSTDIR%\xenlyimg.exe 2>nul
 echo ✓  Uninstalled
 goto end
 
@@ -170,6 +191,7 @@ echo   Targets:
 echo     all              Build xenlybyc + xenlyrun (default)
 echo     xenlybyc         Build the bytecode compiler only
 echo     xenlyrun         Build the VM launcher only
+echo     xenlyimg         Build the native image builder only
 echo     test             Build and run test suite
 echo     fmt              Auto-format all Go source
 echo     vet              Run go vet on all packages
@@ -189,6 +211,7 @@ echo     main.bat                     # build both tools
 echo     main.bat test                # build + smoke test
 echo     %BINDIR%\xenlybyc hello.xe      # compile hello.xe → hello.xyc
 echo     %BINDIR%\xenlyrun  hello.xyc    # run compiled bytecode
+echo     %BINDIR%\xenlyimg  hello.xyc -o hello.exe  # build native executable
 echo     %BINDIR%\xenlyrun --run hello.xe  # compile + run in one step
 echo     main.bat cross-all           # build for all platforms
 echo.

--- a/xvm/pkg/bytecode/format.go
+++ b/xvm/pkg/bytecode/format.go
@@ -56,6 +56,7 @@
 package bytecode
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -321,37 +322,47 @@ func Read(path string) (*Module, error) {
 	}
 	defer f.Close()
 
+	return ReadFrom(f)
+}
+
+// ReadBytes decodes a Module from an in-memory XVM bytecode image.
+func ReadBytes(data []byte) (*Module, error) {
+	return ReadFrom(bytes.NewReader(data))
+}
+
+// ReadFrom decodes a Module from an XVM bytecode stream.
+func ReadFrom(r io.Reader) (*Module, error) {
 	le := binary.LittleEndian
 
 	readU8 := func() (uint8, error) {
 		var v uint8
-		err := binary.Read(f, le, &v)
+		err := binary.Read(r, le, &v)
 		return v, err
 	}
 	readU16 := func() (uint16, error) {
 		var v uint16
-		err := binary.Read(f, le, &v)
+		err := binary.Read(r, le, &v)
 		return v, err
 	}
 	readU32 := func() (uint32, error) {
 		var v uint32
-		err := binary.Read(f, le, &v)
+		err := binary.Read(r, le, &v)
 		return v, err
 	}
 	readU64 := func() (uint64, error) {
 		var v uint64
-		err := binary.Read(f, le, &v)
+		err := binary.Read(r, le, &v)
 		return v, err
 	}
 	readBytes := func(n uint32) ([]byte, error) {
 		b := make([]byte, n)
-		_, err := io.ReadFull(f, b)
+		_, err := io.ReadFull(r, b)
 		return b, err
 	}
 
 	// Header
 	var magic [4]byte
-	if _, err := io.ReadFull(f, magic[:]); err != nil {
+	if _, err := io.ReadFull(r, magic[:]); err != nil {
 		return nil, fmt.Errorf("read magic: %w", err)
 	}
 	if magic != Magic {

--- a/xvm/pkg/vm/value.go
+++ b/xvm/pkg/vm/value.go
@@ -164,9 +164,35 @@ func Array(items []*Value) *Value {
 	}
 	return &Value{Tag: TypeArray, ArrayVal: items}
 }
+func newValueMap(sizeHint int) map[string]*Value {
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	// Go gives each map an unpredictable hash seed. Keeping VM object tables
+	// behind this constructor makes that randomized-hash-table property explicit
+	// for user-controlled property names and helps avoid collision-based DoS.
+	return make(map[string]*Value, sizeHint)
+}
+
+func newEnvEntryMap(sizeHint int) map[string]*envEntry {
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	// Environment overflow tables also receive Go's per-map random hash seed.
+	return make(map[string]*envEntry, sizeHint)
+}
+
+func newMethodMap(sizeHint int) map[string]*FunctionVal {
+	if sizeHint < 0 {
+		sizeHint = 0
+	}
+	// Method lookup tables are randomized maps too, protecting class member names.
+	return make(map[string]*FunctionVal, sizeHint)
+}
+
 func Object(m map[string]*Value) *Value {
 	if m == nil {
-		m = make(map[string]*Value)
+		m = newValueMap(0)
 	}
 	return &Value{Tag: TypeObject, ObjVal: m}
 }
@@ -218,7 +244,7 @@ func (v *Value) Clone() *Value {
 		if v.ObjVal == nil {
 			return Object(nil)
 		}
-		cloned := make(map[string]*Value)
+		cloned := newValueMap(len(v.ObjVal))
 		for k, val := range v.ObjVal {
 			cloned[k] = val.Clone()
 		}
@@ -246,7 +272,7 @@ func (v *Value) Clone() *Value {
 		if v.InstVal == nil {
 			return &Value{Tag: TypeInstance, InstVal: nil}
 		}
-		clonedFields := make(map[string]*Value)
+		clonedFields := newValueMap(len(v.InstVal.Fields))
 		for k, val := range v.InstVal.Fields {
 			clonedFields[k] = val.Clone()
 		}
@@ -507,7 +533,7 @@ func (e *Env) Define(name string, val *Value, isConst bool) {
 		return
 	}
 	if e.overflow == nil {
-		e.overflow = make(map[string]*envEntry, 8)
+		e.overflow = newEnvEntryMap(8)
 	}
 	e.overflow[name] = &envEntry{name: name, value: val, isConst: isConst}
 }

--- a/xvm/pkg/vm/vm.go
+++ b/xvm/pkg/vm/vm.go
@@ -135,7 +135,7 @@ func (xvm *XVM) buildClasses() {
 	for i, cd := range xvm.module.Classes {
 		xvm.classes[i] = &ClassVal{
 			Name:    xvm.poolStr(cd.NameIdx),
-			Methods: make(map[string]*FunctionVal),
+			Methods: newMethodMap(len(cd.Methods)),
 		}
 	}
 	for i, cd := range xvm.module.Classes {
@@ -616,7 +616,7 @@ func (xvm *XVM) exec(code []byte, env *Env, thisVal *Value, class *ClassVal) (*V
 		// ── Objects ──────────────────────────────────────────────────────────
 		case bytecode.OP_MAKE_OBJ:
 			count := int(readU32(&ip))
-			m := make(map[string]*Value, count)
+			m := newValueMap(count)
 			// For small objects (≤ 8 pairs) use a stack-allocated array to
 			// collect pairs instead of heap-allocating a []*Value slice.
 			if count <= 8 {
@@ -1178,13 +1178,13 @@ func (xvm *XVM) propSet(obj *Value, name string, val *Value) {
 	switch obj.Tag {
 	case TypeObject:
 		if obj.ObjVal == nil {
-			obj.ObjVal = make(map[string]*Value)
+			obj.ObjVal = newValueMap(0)
 		}
 		obj.ObjVal[name] = val
 	case TypeInstance:
 		if obj.InstVal != nil {
 			if obj.InstVal.Fields == nil {
-				obj.InstVal.Fields = make(map[string]*Value)
+				obj.InstVal.Fields = newValueMap(0)
 			}
 			obj.InstVal.Fields[name] = val
 		}
@@ -1246,7 +1246,7 @@ func (xvm *XVM) indexSet(container *Value, idx *Value, val *Value) {
 		}
 	case TypeObject:
 		if container.ObjVal == nil {
-			container.ObjVal = make(map[string]*Value)
+			container.ObjVal = newValueMap(0)
 		}
 		container.ObjVal[idx.String()] = val
 	}
@@ -1272,7 +1272,7 @@ func (xvm *XVM) instantiateClassVal(cls *ClassVal, args []*Value) (*Value, error
 	}
 	inst := &InstanceVal{
 		Class:  cls,
-		Fields: make(map[string]*Value),
+		Fields: newValueMap(0),
 	}
 	instVal := &Value{Tag: TypeInstance, InstVal: inst}
 
@@ -1904,13 +1904,14 @@ func (xvm *XVM) objectMethod(obj *Value, name string, args []*Value) (*Value, bo
 // ─── Variant method dispatch ──────────────────────────────────────────────────
 // Implements the Optional / ADT API on TypeVariant values.
 // Supports the Some(x) / None pattern used in functional.xe and elsewhere:
-//   some.getOr(default)  →  inner value (Some) or default (None)
-//   some.isSome()        →  true if tag != "None"
-//   some.isNone()        →  true if tag == "None"
-//   some.unwrap()        →  inner value or runtime error on None
-//   some.orElse(fn)      →  self (Some) or fn() result (None)
-//   some.map(fn)         →  Some(fn(inner)) or None  (functor map)
-//   some.tag()           →  variant tag string
+//
+//	some.getOr(default)  →  inner value (Some) or default (None)
+//	some.isSome()        →  true if tag != "None"
+//	some.isNone()        →  true if tag == "None"
+//	some.unwrap()        →  inner value or runtime error on None
+//	some.orElse(fn)      →  self (Some) or fn() result (None)
+//	some.map(fn)         →  Some(fn(inner)) or None  (functor map)
+//	some.tag()           →  variant tag string
 func (xvm *XVM) variantMethod(v *Value, name string, args []*Value) (*Value, bool, error) {
 	isNone := v.VarTag == "None" || len(v.VarFields) == 0
 	switch name {
@@ -2031,7 +2032,7 @@ func (xvm *XVM) nullMethod(name string, args []*Value) (*Value, bool, error) {
 // Numbers and bools are always "present" values so they participate in Optional
 // chaining without any wrapping.  This makes code like:
 //
-//   const n = maybeNum.getOr(0)   // works whether maybeNum is a number or null
+//	const n = maybeNum.getOr(0)   // works whether maybeNum is a number or null
 //
 // work uniformly regardless of the runtime type.
 //

--- a/xvm/xenlyimg/main.go
+++ b/xvm/xenlyimg/main.go
@@ -77,17 +77,57 @@ func splitTarget(target string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
+func findModuleRootFrom(start string) (string, bool) {
+	if start == "" {
+		return "", false
+	}
+	start, err := filepath.Abs(start)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(start)
+	if err == nil && !info.IsDir() {
+		start = filepath.Dir(start)
+	}
+	for {
+		gomod := filepath.Join(start, "go.mod")
+		if data, err := os.ReadFile(gomod); err == nil && strings.Contains(string(data), "module xvm") {
+			return start, true
+		}
+		parent := filepath.Dir(start)
+		if parent == start {
+			return "", false
+		}
+		start = parent
+	}
+}
+
 func moduleRoot() (string, error) {
+	if root, ok := findModuleRootFrom(os.Getenv("XVM_ROOT")); ok {
+		return root, nil
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if root, ok := findModuleRootFrom(cwd); ok {
+			return root, nil
+		}
+	}
+	if exe, err := os.Executable(); err == nil {
+		if root, ok := findModuleRootFrom(exe); ok {
+			return root, nil
+		}
+	}
+
 	cmd := exec.Command("go", "env", "GOMOD")
 	out, err := cmd.Output()
-	if err != nil {
-		return "", err
+	if err == nil {
+		gomod := strings.TrimSpace(string(out))
+		if gomod != "" && gomod != os.DevNull {
+			if root, ok := findModuleRootFrom(gomod); ok {
+				return root, nil
+			}
+		}
 	}
-	gomod := strings.TrimSpace(string(out))
-	if gomod == "" || gomod == os.DevNull {
-		return "", fmt.Errorf("cannot locate xvm/go.mod")
-	}
-	return filepath.Dir(gomod), nil
+	return "", fmt.Errorf("cannot locate xvm/go.mod; run from the xvm tree or set XVM_ROOT")
 }
 
 func writeBuildFiles(dir, moduleDir, encoded string) error {
@@ -203,6 +243,11 @@ func main() {
 	}
 	if outputFile == "" {
 		outputFile = defaultOutput(inputFile, goos)
+	}
+	outputFile, err = filepath.Abs(outputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] cannot resolve output path: %v\n", err)
+		os.Exit(1)
 	}
 	moduleDir, err := moduleRoot()
 	if err != nil {

--- a/xvm/xenlyimg/main.go
+++ b/xvm/xenlyimg/main.go
@@ -1,0 +1,245 @@
+/*
+ * XENLY - Xenly Virtual Machine (XVM)
+ * xenlyimg — XVM Native Image Builder
+ *
+ * Compiles portable XVM bytecode (.xebc/.xyc) into a standalone,
+ * platform-specific native executable by embedding the bytecode image into a
+ * small optimized XVM runner and invoking the Go AOT toolchain.
+ */
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"xvm/pkg/bytecode"
+)
+
+const (
+	xenlyimgVersion = "1.0.0"
+	xenlyimgAuthor  = "Cyril John Magayaga"
+)
+
+var useColor = true
+
+func col(code string) string {
+	if !useColor {
+		return ""
+	}
+	return "\033[" + code + "m"
+}
+
+func reset() string {
+	if !useColor {
+		return ""
+	}
+	return "\033[0m"
+}
+
+func usage(prog string) {
+	fmt.Printf("\n  %sxenlyimg%s  XVM Native Image Builder  %sv%s%s\n", col("1;36"), reset(), col("1;33"), xenlyimgVersion, reset())
+	fmt.Printf("\n  %sUsage:%s   %s [options] <file.xebc|file.xyc>\n", col("1;33"), reset(), prog)
+	fmt.Printf("\n  %sOptions:%s\n", col("1;33"), reset())
+	fmt.Printf("    %s-o <file>%s             Output native executable (default: input name)\n", col("1"), reset())
+	fmt.Printf("    %s--target <os/arch>%s    Build for linux/amd64, darwin/arm64, windows/amd64, ...\n", col("1"), reset())
+	fmt.Printf("    %s--workdir <dir>%s       Keep generated native-image build directory\n", col("1"), reset())
+	fmt.Printf("    %s--no-color%s            Disable ANSI colour output\n", col("1"), reset())
+	fmt.Printf("    %s--time%s                Show image build time\n", col("1"), reset())
+	fmt.Printf("    %s-h, --help%s            Show this help\n", col("1"), reset())
+	fmt.Printf("    %s-v, --version%s         Show version\n", col("1"), reset())
+	fmt.Printf("\n  %sPipeline:%s\n", col("1;32"), reset())
+	fmt.Printf("    xenlybyc hello.xe -o hello.xebc\n")
+	fmt.Printf("    %s hello.xebc -o hello%s\n\n", prog, reset())
+}
+
+func defaultOutput(input, targetOS string) string {
+	base := strings.TrimSuffix(input, filepath.Ext(input))
+	if targetOS == "windows" && !strings.HasSuffix(strings.ToLower(base), ".exe") {
+		return base + ".exe"
+	}
+	return base
+}
+
+func splitTarget(target string) (string, string, error) {
+	if target == "" {
+		return runtime.GOOS, runtime.GOARCH, nil
+	}
+	parts := strings.Split(target, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("target must be in GOOS/GOARCH form, got %q", target)
+	}
+	return parts[0], parts[1], nil
+}
+
+func moduleRoot() (string, error) {
+	cmd := exec.Command("go", "env", "GOMOD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	gomod := strings.TrimSpace(string(out))
+	if gomod == "" || gomod == os.DevNull {
+		return "", fmt.Errorf("cannot locate xvm/go.mod")
+	}
+	return filepath.Dir(gomod), nil
+}
+
+func writeBuildFiles(dir, moduleDir, encoded string) error {
+	gomod := "module xenlyimgbuild\n\ngo 1.21\n\nrequire xvm v0.0.0\n\nreplace xvm => " + filepath.ToSlash(moduleDir) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		return err
+	}
+	mainSrc := fmt.Sprintf(`package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"xvm/pkg/bytecode"
+	"xvm/pkg/vm"
+)
+
+const embeddedBytecode = %q
+
+func main() {
+	data, err := base64.StdEncoding.DecodeString(embeddedBytecode)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] embedded bytecode error: %%v\n", err)
+		os.Exit(1)
+	}
+	mod, err := bytecode.ReadBytes(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] bytecode decode error: %%v\n", err)
+		os.Exit(1)
+	}
+	stdout := bufio.NewWriter(os.Stdout)
+	vm.SetStdout(stdout)
+	defer stdout.Flush()
+	if err := vm.NewXVM(mod).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] runtime error: %%v\n", err)
+		os.Exit(1)
+	}
+}
+`, encoded)
+	return os.WriteFile(filepath.Join(dir, "main.go"), []byte(mainSrc), 0o644)
+}
+
+func main() {
+	var inputFile, outputFile, target, keepWorkdir string
+	var showTime bool
+
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "--help":
+			usage(os.Args[0])
+			return
+		case "-v", "--version":
+			fmt.Printf("xenlyimg v%s — XVM Native Image Builder\n", xenlyimgVersion)
+			return
+		case "--author":
+			fmt.Printf("xenlyimg — created, designed, and developed by %s\n", xenlyimgAuthor)
+			return
+		case "--no-color":
+			useColor = false
+		case "--time":
+			showTime = true
+		case "-o":
+			i++
+			if i >= len(args) {
+				fmt.Fprintln(os.Stderr, "[xenlyimg] -o requires a file")
+				os.Exit(1)
+			}
+			outputFile = args[i]
+		case "--target":
+			i++
+			if i >= len(args) {
+				fmt.Fprintln(os.Stderr, "[xenlyimg] --target requires GOOS/GOARCH")
+				os.Exit(1)
+			}
+			target = args[i]
+		case "--workdir":
+			i++
+			if i >= len(args) {
+				fmt.Fprintln(os.Stderr, "[xenlyimg] --workdir requires a directory")
+				os.Exit(1)
+			}
+			keepWorkdir = args[i]
+		default:
+			if strings.HasPrefix(args[i], "-") {
+				fmt.Fprintf(os.Stderr, "[xenlyimg] unknown option %q\n", args[i])
+				os.Exit(1)
+			}
+			inputFile = args[i]
+		}
+	}
+	if inputFile == "" {
+		usage(os.Args[0])
+		os.Exit(1)
+	}
+
+	t0 := time.Now()
+	if _, err := bytecode.Read(inputFile); err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] cannot load %q: %v\n", inputFile, err)
+		os.Exit(1)
+	}
+	data, err := os.ReadFile(inputFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] cannot read %q: %v\n", inputFile, err)
+		os.Exit(1)
+	}
+	goos, goarch, err := splitTarget(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] %v\n", err)
+		os.Exit(1)
+	}
+	if outputFile == "" {
+		outputFile = defaultOutput(inputFile, goos)
+	}
+	moduleDir, err := moduleRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] %v\n", err)
+		os.Exit(1)
+	}
+	workdir := keepWorkdir
+	if workdir == "" {
+		workdir, err = os.MkdirTemp("", "xenlyimg-*")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "[xenlyimg] %v\n", err)
+			os.Exit(1)
+		}
+		defer os.RemoveAll(workdir)
+	} else if err := os.MkdirAll(workdir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] %v\n", err)
+		os.Exit(1)
+	}
+	if err := writeBuildFiles(workdir, moduleDir, base64.StdEncoding.EncodeToString(data)); err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] cannot write build files: %v\n", err)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command("go", "build", "-trimpath", "-ldflags=-s -w", "-o", outputFile, ".")
+	cmd.Dir = workdir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "[xenlyimg] native image build failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("%s[xenlyimg]%s native executable: %s (%s/%s)\n", col("1;32"), reset(), outputFile, goos, goarch)
+	if keepWorkdir != "" {
+		fmt.Printf("%s[xenlyimg]%s build directory: %s\n", col("1;33"), reset(), workdir)
+	}
+	if showTime {
+		fmt.Printf("%s[xenlyimg]%s image build time: %.2f ms\n", col("1;36"), reset(), float64(time.Since(t0).Microseconds())/1000)
+	}
+}

--- a/xvm/xenlyimg/main_test.go
+++ b/xvm/xenlyimg/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"xvm/pkg/bytecode"
+	"xvm/pkg/compiler"
+)
+
+func compileTestBytecode(t *testing.T, out string) {
+	t.Helper()
+	lexer := compiler.NewLexer(`print("xenlyimg-test")`)
+	tokens, lexErrs := lexer.Tokenize()
+	if len(lexErrs) > 0 {
+		t.Fatalf("lex errors: %v", lexErrs)
+	}
+	parser := compiler.NewParser(tokens)
+	ast, parseErrs := parser.Parse()
+	if len(parseErrs) > 0 {
+		t.Fatalf("parse errors: %v", parseErrs)
+	}
+	mod, compErrs := compiler.NewCompiler().Compile(ast)
+	if len(compErrs) > 0 {
+		t.Fatalf("compile errors: %v", compErrs)
+	}
+	if err := bytecode.Write(mod, out); err != nil {
+		t.Fatalf("write bytecode: %v", err)
+	}
+}
+
+func TestSplitTarget(t *testing.T) {
+	goos, goarch, err := splitTarget("linux/amd64")
+	if err != nil {
+		t.Fatalf("splitTarget returned error: %v", err)
+	}
+	if goos != "linux" || goarch != "amd64" {
+		t.Fatalf("splitTarget = %s/%s, want linux/amd64", goos, goarch)
+	}
+	if _, _, err := splitTarget("linux-amd64"); err == nil {
+		t.Fatal("splitTarget accepted malformed target")
+	}
+}
+
+func TestFindModuleRootFrom(t *testing.T) {
+	root, ok := findModuleRootFrom(".")
+	if !ok {
+		t.Fatal("findModuleRootFrom did not locate xvm module from package cwd")
+	}
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("module root does not contain go.mod: %v", err)
+	}
+}
+
+func TestXenlyimgBuildsRelativeOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping native image integration test in short mode")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skipf("go toolchain not available: %v", err)
+	}
+
+	tmp := t.TempDir()
+	bytecodePath := filepath.Join(tmp, "hello.xebc")
+	compileTestBytecode(t, bytecodePath)
+
+	outputName := "hello-native"
+	if runtime.GOOS == "windows" {
+		outputName += ".exe"
+	}
+	cmd := exec.Command("go", "run", ".", bytecodePath, "-o", outputName, "--no-color")
+	cmd.Dir = "."
+	cmd.Env = append(os.Environ(), "XVM_ROOT=..")
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("xenlyimg failed: %v\n%s", err, combined.String())
+	}
+
+	outputPath, err := filepath.Abs(outputName)
+	if err != nil {
+		t.Fatalf("resolve output path: %v", err)
+	}
+	if _, err := os.Stat(outputPath); err != nil {
+		t.Fatalf("relative output was not created in caller directory: %v\n%s", err, combined.String())
+	}
+	defer os.Remove(outputPath)
+
+	run := exec.Command(outputPath)
+	var runOut bytes.Buffer
+	run.Stdout = &runOut
+	run.Stderr = &runOut
+	if err := run.Run(); err != nil {
+		t.Fatalf("native image failed: %v\n%s", err, runOut.String())
+	}
+	if got := runOut.String(); got != "xenlyimg-test\n" {
+		t.Fatalf("native image output = %q, want %q", got, "xenlyimg-test\n")
+	}
+}


### PR DESCRIPTION
### Motivation
- Prevent collision-based denial-of-service attacks by making XVM internal maps explicit and routed through centralized constructors so they benefit from Go's per-map randomized hash seed.
- Make map allocation for VM objects, instance fields, class method tables, and environment overflow consistent and documented.

### Description
- Added three helper constructors in `xvm/pkg/vm/value.go`: `newValueMap(sizeHint int)`, `newEnvEntryMap(sizeHint int)`, and `newMethodMap(sizeHint int)` with comments explaining the use of Go's randomized map hashing.
- Replaced direct `make(map[string]...` usages with the new helpers in `xvm/pkg/vm/value.go` and `xvm/pkg/vm/vm.go`, including `Object()` initialization, deep clone paths, `Env` overflow allocation, class `Methods` creation, `OP_MAKE_OBJ` object literals, `propSet` / `indexSet` object initializations, and instance `Fields` initialization.
- Kept behavior identical except for centralizing map creation; capacity hints are preserved where available (e.g. `newMethodMap(len(cd.Methods))`, `newValueMap(count)`).

### Testing
- Ran `go test ./...` in `xvm/`, which completed successfully (packages contain no test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34829ee368833396812a1dcd266fe6)